### PR TITLE
Fix OnPopulateMesh not called

### DIFF
--- a/UI Shapes Kit/Scripts/Runtime/Geometry/Shapes/Arc.cs
+++ b/UI Shapes Kit/Scripts/Runtime/Geometry/Shapes/Arc.cs
@@ -5,6 +5,7 @@ using System.Collections;
 namespace ThisOtherThing.UI.Shapes
 {
 	[AddComponentMenu("UI/Shapes/Arc", 50)]
+	[RequireComponent(typeof(CanvasRenderer))]
 	public class Arc : MaskableGraphic, IShape
 	{
 		public GeoUtils.ShapeProperties ShapeProperties =

--- a/UI Shapes Kit/Scripts/Runtime/Geometry/Shapes/EdgeGradient.cs
+++ b/UI Shapes Kit/Scripts/Runtime/Geometry/Shapes/EdgeGradient.cs
@@ -6,6 +6,7 @@ namespace ThisOtherThing.UI.Shapes
 {
 
 	[AddComponentMenu("UI/Shapes/Edge Gradient", 100)]
+	[RequireComponent(typeof(CanvasRenderer))]
 	public class EdgeGradient : MaskableGraphic, IShape
 	{
 		public enum Positions

--- a/UI Shapes Kit/Scripts/Runtime/Geometry/Shapes/Ellipse.cs
+++ b/UI Shapes Kit/Scripts/Runtime/Geometry/Shapes/Ellipse.cs
@@ -5,6 +5,7 @@ using System.Collections;
 namespace ThisOtherThing.UI.Shapes
 {
 	[AddComponentMenu("UI/Shapes/Ellipse", 1)]
+	[RequireComponent(typeof(CanvasRenderer))]
 	public class Ellipse : MaskableGraphic, IShape
 	{
         public override Color color

--- a/UI Shapes Kit/Scripts/Runtime/Geometry/Shapes/EmptyFillRect.cs
+++ b/UI Shapes Kit/Scripts/Runtime/Geometry/Shapes/EmptyFillRect.cs
@@ -5,6 +5,7 @@ namespace ThisOtherThing.UI.Shapes
 {
 
 	[AddComponentMenu("UI/Shapes/Empty Fill Rect", 200)]
+	[RequireComponent(typeof(CanvasRenderer))]
 	public class EmptyFillRect : Graphic
 	{
 		public override void SetMaterialDirty() { return; }

--- a/UI Shapes Kit/Scripts/Runtime/Geometry/Shapes/Line.cs
+++ b/UI Shapes Kit/Scripts/Runtime/Geometry/Shapes/Line.cs
@@ -5,6 +5,7 @@ using System.Collections;
 namespace ThisOtherThing.UI.Shapes
 {
 	[AddComponentMenu("UI/Shapes/Line", 30)]
+	[RequireComponent(typeof(CanvasRenderer))]
 	public class Line : MaskableGraphic, IShape
 	{
 		public GeoUtils.ShapeProperties ShapeProperties =

--- a/UI Shapes Kit/Scripts/Runtime/Geometry/Shapes/PixelLine.cs
+++ b/UI Shapes Kit/Scripts/Runtime/Geometry/Shapes/PixelLine.cs
@@ -5,6 +5,7 @@ using System.Collections;
 namespace ThisOtherThing.UI.Shapes
 {
 	[AddComponentMenu("UI/Shapes/Pixel Line", 100)]
+	[RequireComponent(typeof(CanvasRenderer))]
 	public class PixelLine : MaskableGraphic, IShape
 	{
 

--- a/UI Shapes Kit/Scripts/Runtime/Geometry/Shapes/Polygon.cs
+++ b/UI Shapes Kit/Scripts/Runtime/Geometry/Shapes/Polygon.cs
@@ -6,6 +6,7 @@ namespace ThisOtherThing.UI.Shapes
 {
 
 	[AddComponentMenu("UI/Shapes/Polygon", 30)]
+	[RequireComponent(typeof(CanvasRenderer))]
 	public class Polygon : MaskableGraphic, IShape
 	{
 

--- a/UI Shapes Kit/Scripts/Runtime/Geometry/Shapes/Rectangle.cs
+++ b/UI Shapes Kit/Scripts/Runtime/Geometry/Shapes/Rectangle.cs
@@ -5,6 +5,7 @@ using System.Collections;
 namespace ThisOtherThing.UI.Shapes
 {
 	[AddComponentMenu("UI/Shapes/Rectangle", 1)]
+	[RequireComponent(typeof(CanvasRenderer))]
 	public class Rectangle : MaskableGraphic, IShape
 	{
         // todo: add override colors for the other shapes

--- a/UI Shapes Kit/Scripts/Runtime/Geometry/Shapes/Sector.cs
+++ b/UI Shapes Kit/Scripts/Runtime/Geometry/Shapes/Sector.cs
@@ -5,6 +5,7 @@ using System.Collections;
 namespace ThisOtherThing.UI.Shapes
 {
 	[AddComponentMenu("UI/Shapes/Sector", 50)]
+	[RequireComponent(typeof(CanvasRenderer))]
 	public class Sector : MaskableGraphic, IShape
 	{
 		public GeoUtils.ShapeProperties ShapeProperties =


### PR DESCRIPTION
On Unity 2020.1 and newer, OnPopulateMesh is not being called when there is no CanvasRenderer on the GameObject. This fix will automatically create it.